### PR TITLE
Handle RSS and HTML sources in news digest workflow

### DIFF
--- a/workflow_definitions/news_digest_workflow/README.md
+++ b/workflow_definitions/news_digest_workflow/README.md
@@ -1,6 +1,6 @@
 # News Digest Workflow
 
-This workflow collects recent news from preset web resources, summarizes the updates with a local LLM and emails the digest.
+This workflow collects recent news from preset resources—a mix of RSS feeds and standard web pages—summarizes the updates with a local LLM and emails the digest.
 
 ## Setup
 

--- a/workflow_definitions/news_digest_workflow/news_digest_workflow.py
+++ b/workflow_definitions/news_digest_workflow/news_digest_workflow.py
@@ -1,18 +1,29 @@
 import os
 from datetime import datetime, timedelta
 from email.message import EmailMessage
+import logging
 import smtplib
+from enum import Enum
+from urllib.parse import urljoin
+
 import feedparser
+import requests
+from bs4 import BeautifulSoup
+from dateutil import parser as dateparser
 from pydantic import BaseModel, Field
 from langchain_openai import ChatOpenAI
-import logging
 
 logger = logging.getLogger(__name__)
 
 
+class ResourceType(str, Enum):
+    RSS = "rss"
+    WEB = "web"
+
+
 class NewsResource(BaseModel):
     url: str = Field(description="Resource URL")
-    type: str = Field(description="Type of the resource e.g. web, twitter")
+    type: ResourceType = Field(description="Type of the resource")
 
 
 class NewsItem(BaseModel):
@@ -24,9 +35,9 @@ class NewsItem(BaseModel):
 
 def get_resources(trigger: str, config: dict) -> dict:
     resources = [
-        {"url": "https://karpathy.bearblog.dev/blog/", "type": "web"},
-        {"url": "https://www.anthropic.com/news", "type": "web"},
-        {"url": "https://openai.com/news/research/", "type": "web"},
+        {"url": "https://karpathy.bearblog.dev/rss", "type": ResourceType.RSS},
+        {"url": "https://www.anthropic.com/news", "type": ResourceType.WEB},
+        {"url": "https://openai.com/news/research/", "type": ResourceType.WEB},
     ]
     return {"resources": [NewsResource(**r) for r in resources]}
 
@@ -35,25 +46,59 @@ def fetch_news(resources: list[NewsResource], config: dict) -> dict:
     days_back = config.get("days_back", 7)
     start_date = datetime.utcnow() - timedelta(days=days_back)
     news_items: list[NewsItem] = []
+    headers = {"User-Agent": "Mozilla/5.0"}
 
     for res in resources:
-        if res.type != "web":
-            continue
-        feed = feedparser.parse(res.url)
-        for entry in getattr(feed, "entries", []):
-            published_parsed = getattr(entry, "published_parsed", None) or getattr(entry, "updated_parsed", None)
-            if not published_parsed:
-                continue
-            published = datetime(*published_parsed[:6])
-            if published < start_date:
-                continue
-            summary = entry.get("summary", "")
-            news_items.append(
-                NewsItem(title=entry.get("title", ""),
-                         link=entry.get("link", ""),
-                         published=published,
-                         summary=summary)
-            )
+        try:
+            if res.type == ResourceType.RSS:
+                feed = feedparser.parse(res.url)
+                for entry in getattr(feed, "entries", []):
+                    published_parsed = getattr(entry, "published_parsed", None) or getattr(entry, "updated_parsed", None)
+                    if not published_parsed:
+                        continue
+                    published = datetime(*published_parsed[:6])
+                    if published < start_date:
+                        continue
+                    summary = entry.get("summary", "")
+                    news_items.append(
+                        NewsItem(
+                            title=entry.get("title", ""),
+                            link=entry.get("link", ""),
+                            published=published,
+                            summary=summary,
+                        )
+                    )
+            elif res.type == ResourceType.WEB:
+                resp = requests.get(res.url, headers=headers, timeout=10)
+                if resp.status_code != 200:
+                    continue
+                soup = BeautifulSoup(resp.text, "html.parser")
+                for a in soup.find_all("a"):
+                    href = a.get("href")
+                    text = a.get_text(" ", strip=True)
+                    if not href or not text:
+                        continue
+                    context = a.parent.get_text(" ", strip=True)
+                    try:
+                        published = dateparser.parse(context, fuzzy=True)
+                    except Exception:
+                        continue
+                    if published < start_date:
+                        continue
+                    link = urljoin(res.url, href)
+                    summary = ""
+                    try:
+                        article = requests.get(link, headers=headers, timeout=10)
+                        art_soup = BeautifulSoup(article.text, "html.parser")
+                        summary = " ".join(art_soup.get_text(" ", strip=True).split())[:500]
+                    except Exception:
+                        pass
+                    news_items.append(
+                        NewsItem(title=text, link=link, published=published, summary=summary)
+                    )
+        except Exception as e:
+            logger.warning(f"Failed to parse {res.url}: {e}")
+
     return {"news_items": news_items}
 
 
@@ -103,3 +148,4 @@ def send_email(summary: str, config: dict) -> dict:
         raise e
 
     return {"success": True}
+

--- a/workflow_definitions/news_digest_workflow/requirements.txt
+++ b/workflow_definitions/news_digest_workflow/requirements.txt
@@ -1,2 +1,5 @@
 feedparser
 langchain-openai
+requests
+beautifulsoup4
+python-dateutil


### PR DESCRIPTION
## Summary
- Distinguish resource types for news sources and mark Karpathy blog as RSS while Anthropic and OpenAI pages are HTML
- Parse RSS feeds and scrape HTML pages to collect news, then summarize and email
- Add HTML parsing dependencies and mention mixed source types in workflow docs

## Testing
- `.venv/bin/pytest workflow_definitions/news_digest_workflow/tests/test_workflow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5923fea2c8332bc573160b052b39f