### PR TITLE
Revamp workflow table layout and modal details

### DIFF
--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -4,12 +4,13 @@
   --success-color: #10b981;
   --warning-color: #f59e0b;
   --error-color: #ef4444;
-  --background-color: #f8fafc;
+  --background-color: #f1f5f9;
   --card-background: #ffffff;
   --border-color: #e2e8f0;
-  --text-primary: #1e293b;
+  --text-primary: #0f172a;
   --text-secondary: #64748b;
-  --hover-color: #f1f5f9;
+  --hover-color: #f8fafc;
+  --shadow-color: rgba(15, 23, 42, 0.08);
 }
 
 * {
@@ -20,601 +21,484 @@
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-  line-height: 1.6;
-  color: var(--text-primary);
+  line-height: 1.5;
   background-color: var(--background-color);
+  color: var(--text-primary);
 }
 
-.container {
+.app-shell {
+  min-height: 100vh;
   display: flex;
-  height: 100vh;
+  flex-direction: column;
   background-color: var(--background-color);
-}
-
-/* Sidebar Styles */
-.sidebar {
-  width: 280px;
-  border-right: 1px solid var(--border-color);
-  padding: 1.5rem;
-  background-color: var(--card-background);
-  box-shadow: 2px 0 4px rgba(0, 0, 0, 0.1);
-}
-
-.sidebar h2 {
-  margin-bottom: 1.5rem;
   color: var(--text-primary);
-  font-size: 1.25rem;
-  font-weight: 600;
 }
 
-.workflow-list {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 1.5rem 0;
-}
-
-.workflow-list li {
-  padding: 1rem;
-  cursor: pointer;
+.app-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-radius: 10px;
-  margin-bottom: 0.75rem;
-  transition: all 0.2s ease;
-  border: 1px solid var(--border-color);
-  background-color: var(--background-color);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  padding: 1.75rem 2.5rem;
+  background-color: var(--card-background);
+  border-bottom: 1px solid var(--border-color);
+  box-shadow: 0 8px 20px -12px var(--shadow-color);
 }
 
-.workflow-list li:hover {
-  background-color: #f8fafc;
-  border-color: var(--primary-color);
-  transform: translateY(-1px);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+.header-titles h1 {
+  font-size: 2rem;
+  font-weight: 600;
+  margin: 0;
 }
 
-.workflow-list li.selected {
+.subtitle {
+  margin-top: 0.3rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.primary-btn {
   background-color: var(--primary-color);
-  color: white;
-  border-color: var(--primary-color);
-  box-shadow: 0 3px 6px rgba(37, 99, 235, 0.3);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.8rem 1.6rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 8px 18px -10px rgba(37, 99, 235, 0.6);
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
-.workflow-list li.selected:hover {
+.primary-btn:hover {
   background-color: #1d4ed8;
+  box-shadow: 0 12px 24px -12px rgba(37, 99, 235, 0.7);
   transform: translateY(-1px);
 }
 
-.workflow-list li.selected .state {
-  background-color: rgba(255, 255, 255, 0.2);
-  color: white;
-  border: 1px solid rgba(255, 255, 255, 0.3);
+.primary-btn:active {
+  transform: translateY(0);
 }
 
-.title {
-  font-weight: 500;
+.app-main {
   flex: 1;
-  margin-right: 0.75rem;
-  font-size: 0.9rem;
+  padding: 2.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
 }
 
-.state {
-  font-size: 0.7rem;
-  padding: 0.3rem 0.6rem;
-  border-radius: 12px;
+.table-card {
+  width: 100%;
+  max-width: 1100px;
+  background-color: var(--card-background);
+  border-radius: 20px;
+  box-shadow: 0 20px 45px -30px var(--shadow-color);
+  border: 1px solid var(--border-color);
+  overflow: hidden;
+}
+
+.workflow-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.workflow-table thead {
+  background-color: var(--hover-color);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+}
+
+.workflow-table th,
+.workflow-table td {
+  padding: 1rem 1.25rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border-color);
+  vertical-align: top;
+}
+
+.workflow-table tbody tr {
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.workflow-table tbody tr:hover {
+  background-color: var(--hover-color);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.12);
+}
+
+.workflow-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.06em;
   border: 1px solid transparent;
-  min-width: 80px;
-  text-align: center;
 }
 
-.state-queued {
+.status-queued {
   background-color: #f1f5f9;
   color: #475569;
   border-color: #cbd5e1;
 }
 
-.state-running {
+.status-running {
   background-color: #fef3c7;
   color: #92400e;
   border-color: #f59e0b;
 }
 
-.state-needs-input {
+.status-needs-input {
   background-color: #dbeafe;
-  color: #1e40af;
-  border-color: #3b82f6;
-}
-
-.state-succeeded {
-  background-color: #d1fae5;
-  color: #065f46;
-  border-color: #10b981;
-}
-
-.state-failed {
-  background-color: #fecaca;
-  color: #991b1b;
-  border-color: #ef4444;
-}
-
-.state-canceled {
-  background-color: #e2e8f0;
-  color: #475569;
-  border-color: #94a3b8;
-}
-
-.new-workflow {
-  width: 100%;
-  padding: 0.875rem 1.25rem;
-  background-color: var(--primary-color);
-  color: white;
-  border: none;
-  border-radius: 10px;
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  box-shadow: 0 2px 4px rgba(37, 99, 235, 0.2);
-}
-
-.new-workflow:hover {
-  background-color: #1d4ed8;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(37, 99, 235, 0.3);
-}
-
-.new-workflow:active {
-  transform: translateY(0);
-  box-shadow: 0 2px 4px rgba(37, 99, 235, 0.2);
-}
-
-/* Main Content Styles */
-.content {
-  flex: 1;
-  padding: 2rem;
-  overflow: auto;
-  background-color: var(--background-color);
-}
-
-.workflow-header {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 2rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--border-color);
-}
-
-.workflow-header h2 {
-  font-size: 2rem;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin: 0;
-}
-
-.status-badge {
-  padding: 0.5rem 1rem;
-  border-radius: 20px;
-  font-size: 0.875rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  color: #1d4ed8;
+  border-color: #60a5fa;
 }
 
 .status-succeeded {
-  background-color: #d1fae5;
-  color: #065f46;
-}
-
-.status-running {
-  background-color: #fef3c7;
-  color: #92400e;
-}
-
-.status-needs-input {
-  background-color: #dbeafe;
-  color: #1e40af;
+  background-color: #dcfce7;
+  color: #047857;
+  border-color: #10b981;
 }
 
 .status-failed {
-  background-color: #fecaca;
-  color: #991b1b;
+  background-color: #fee2e2;
+  color: #b91c1c;
+  border-color: #ef4444;
 }
 
 .status-canceled {
   background-color: #e2e8f0;
   color: #475569;
+  border-color: #cbd5e1;
 }
 
-/* Interrupt Section */
-.interrupt-section {
-  background-color: var(--card-background);
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  border: 1px solid var(--border-color);
+.monospace {
+  font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.85rem;
 }
 
-.interrupt-section h3 {
-  margin-bottom: 1rem;
-  color: var(--text-primary);
-  font-size: 1.25rem;
-}
-
-.questions-list {
-  margin-bottom: 1.5rem;
-}
-
-.question {
-  background-color: var(--background-color);
-  padding: 1rem;
-  border-radius: 8px;
-  margin-bottom: 0.5rem;
-  border-left: 4px solid var(--primary-color);
-}
-
-.answer-input {
-  display: flex;
-  gap: 0.75rem;
-  align-items: center;
-}
-
-.answer-field {
-  flex: 1;
-  padding: 0.75rem;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  font-size: 0.875rem;
-  outline: none;
-  transition: border-color 0.2s ease;
-}
-
-.answer-field:focus {
-  border-color: var(--primary-color);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-}
-
-.continue-btn {
-  padding: 0.75rem 1.5rem;
-  background-color: var(--primary-color);
-  color: white;
-  border: none;
-  border-radius: 8px;
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.cancel-btn {
-  padding: 0.75rem 1.5rem;
-  background-color: var(--secondary-color);
-  color: white;
-  border: none;
-  border-radius: 8px;
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.continue-btn:hover {
-  background-color: #1d4ed8;
-  transform: translateY(-1px);
-}
-
-.cancel-btn:hover {
-  background-color: #475569;
-  transform: translateY(-1px);
-}
-
-/* Result Sections */
-.workflow-result {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.result-section {
-  background-color: var(--card-background);
-  border-radius: 12px;
-  border: 1px solid var(--border-color);
+.inputs-preview,
+.error-preview {
+  max-width: 260px;
   overflow: hidden;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.result-section h3 {
-  margin: 0;
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.section-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem 1.5rem;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-  border-bottom: 1px solid var(--border-color);
-}
-
-.section-header:hover {
-  background-color: var(--hover-color);
-}
-
-.toggle-icon {
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  transition: transform 0.2s ease;
-}
-
-.section-content {
-  padding: 1.5rem;
-}
-
-/* Query and Answer Boxes */
-.query-box {
-  padding: 1.5rem;
-  background-color: var(--background-color);
-  border-radius: 8px;
-  border-left: 4px solid var(--primary-color);
-  font-size: 0.95rem;
-  line-height: 1.6;
-}
-
-.final-answer {
-  padding: 1.5rem;
-  background-color: #f0fdf4;
-  border-radius: 8px;
-  border-left: 4px solid var(--success-color);
-  font-size: 0.95rem;
-  line-height: 1.6;
-}
-
-/* Markdown Content Styling */
-.query-box p,
-.final-answer p,
-.section-content p {
-  margin-bottom: 1rem;
-}
-
-.query-box h1,
-.final-answer h1,
-.section-content h1,
-.query-box h2,
-.final-answer h2,
-.section-content h2,
-.query-box h3,
-.final-answer h3,
-.section-content h3 {
-  margin-top: 1.5rem;
-  margin-bottom: 0.75rem;
-  color: var(--text-primary);
-}
-
-.query-box h1:first-child,
-.final-answer h1:first-child,
-.section-content h1:first-child,
-.query-box h2:first-child,
-.final-answer h2:first-child,
-.section-content h2:first-child,
-.query-box h3:first-child,
-.final-answer h3:first-child,
-.section-content h3:first-child {
-  margin-top: 0;
-}
-
-.query-box ul,
-.final-answer ul,
-.section-content ul {
-  margin-left: 1.5rem;
-  margin-bottom: 1rem;
-}
-
-.query-box li,
-.final-answer li,
-.section-content li {
-  margin-bottom: 0.5rem;
-}
-
-.query-box code,
-.final-answer code,
-.section-content code {
-  background-color: #f1f5f9;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
-  font-size: 0.875rem;
-}
-
-.query-box pre,
-.final-answer pre,
-.section-content pre {
-  background-color: #f1f5f9;
-  padding: 1rem;
-  border-radius: 8px;
-  overflow-x: auto;
-  margin-bottom: 1rem;
-  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
-  font-size: 0.875rem;
-}
-
-/* Research Chunks */
-.research-chunks {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.chunk {
-  background-color: var(--background-color);
-  border-radius: 8px;
-  overflow: hidden;
-  border: 1px solid var(--border-color);
-}
-
-.chunk-header {
-  background-color: var(--text-secondary);
-  color: white;
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-}
-
-.chunk-content {
-  padding: 1rem;
-  font-size: 0.875rem;
-  line-height: 1.5;
-  color: var(--text-secondary);
-  max-height: 200px;
-  overflow-y: auto;
-}
-
-/* Workflow Data (Inputs and Results) */
-.workflow-data {
-  background-color: #f8fafc;
-  color: #1e293b;
-  border: 1px solid var(--border-color);
-  padding: 1.5rem;
-  border-radius: 8px;
-  font-size: 0.75rem;
-  line-height: 1.4;
-  overflow-x: auto;
-  max-height: 400px;
-  overflow-y: auto;
-  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
-}
-
-/* Error Data */
-.error-data {
-  background-color: #fef2f2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
-  padding: 1.5rem;
-  border-radius: 8px;
-  font-size: 0.75rem;
-  line-height: 1.4;
-  overflow-x: auto;
-  max-height: 400px;
-  overflow-y: auto;
-  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
-}
-
-/* Questions List */
-.questions-list ul {
-  list-style: none;
-  padding: 0;
-}
-
-.questions-list li {
-  background-color: var(--background-color);
-  padding: 0.75rem;
-  margin-bottom: 0.5rem;
-  border-radius: 6px;
-  border-left: 3px solid var(--primary-color);
-}
-
-/* Empty States */
-.no-result,
-.no-selection {
+.actions-header,
+.actions-cell {
   text-align: center;
-  padding: 4rem 2rem;
+}
+
+.table-continue-btn {
+  background-color: transparent;
+  border: 1px solid var(--primary-color);
+  color: var(--primary-color);
+  border-radius: 999px;
+  padding: 0.45rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.table-continue-btn:hover {
+  background-color: rgba(37, 99, 235, 0.08);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 4rem 1rem;
   color: var(--text-secondary);
+  font-size: 1rem;
 }
 
-.no-result p,
-.no-selection p {
-  font-size: 1.125rem;
-  margin: 0;
-}
-
-/* Responsive Design */
-@media (max-width: 768px) {
-  .container {
-    flex-direction: column;
-    height: auto;
-  }
-
-  .sidebar {
-    width: 100%;
-    border-right: none;
-    border-bottom: 1px solid var(--border-color);
-  }
-
-  .workflow-header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.5rem;
-  }
-
-  .answer-input {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .continue-btn {
-    width: 100%;
-  }
-}
-
-/* Modal */
+/* Modal Styles */
 .modal-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 1.5rem;
   z-index: 1000;
 }
 
 .modal {
   background-color: var(--card-background);
-  padding: 2rem;
-  border-radius: 12px;
-  width: 90%;
-  max-width: 400px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  border-radius: 18px;
+  box-shadow: 0 20px 55px -35px var(--shadow-color);
+  border: 1px solid var(--border-color);
 }
 
-.modal input,
-.modal select {
+.start-modal {
   width: 100%;
-  padding: 0.75rem;
+  max-width: 420px;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.start-modal select,
+.start-modal input {
+  width: 100%;
+  padding: 0.75rem 0.9rem;
+  border-radius: 10px;
   border: 1px solid var(--border-color);
-  border-radius: 8px;
-  margin-bottom: 1rem;
+  font-size: 0.95rem;
 }
 
 .modal-buttons {
   display: flex;
   justify-content: flex-end;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
-.modal-buttons .start-btn {
+.start-btn,
+.cancel-btn,
+.continue-btn {
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+}
+
+.start-btn {
   background-color: var(--primary-color);
-  color: white;
+  color: #fff;
+}
+
+.start-btn:hover {
+  background-color: #1d4ed8;
+}
+
+.cancel-btn {
+  background-color: #e2e8f0;
+  color: #475569;
+}
+
+.cancel-btn:hover {
+  background-color: #cbd5e1;
+}
+
+.continue-btn {
+  background-color: var(--success-color);
+  color: #fff;
+}
+
+.continue-btn:hover {
+  background-color: #0ea366;
+}
+
+.detail-modal {
+  width: 100%;
+  max-width: 760px;
+  padding: 2.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.modal-subtitle {
+  margin-top: 0.25rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.icon-btn {
+  background: transparent;
   border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 8px;
+  font-size: 1.8rem;
+  line-height: 1;
+  color: var(--text-secondary);
   cursor: pointer;
 }
 
-.modal-buttons .cancel-btn {
-  background-color: var(--secondary-color);
-  color: white;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 8px;
+.icon-btn:hover {
+  color: var(--text-primary);
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.detail-grid-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background-color: var(--hover-color);
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+}
+
+.label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+}
+
+.value {
+  font-size: 0.95rem;
+}
+
+.detail-section {
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.85rem 1.1rem;
+  background-color: var(--hover-color);
   cursor: pointer;
+  user-select: none;
+}
+
+.section-header h4 {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.toggle-icon {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.detail-pre {
+  margin: 0;
+  padding: 1.1rem;
+  max-height: 260px;
+  overflow: auto;
+  font-size: 0.85rem;
+  background-color: #0f172a;
+  color: #e2e8f0;
+  font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  border-top: 1px solid var(--border-color);
+}
+
+.error-data {
+  background-color: #7f1d1d;
+}
+
+.detail-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.interrupt-section {
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1.25rem;
+  background-color: #fef3c7;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.questions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.question {
+  margin: 0;
+  font-weight: 500;
+  color: #92400e;
+}
+
+.answer-input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.answer-field {
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  font-size: 0.95rem;
+}
+
+.answer-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+@media (max-width: 960px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .app-main {
+    padding: 1.5rem;
+  }
+
+  .table-card {
+    border-radius: 16px;
+  }
+
+  .detail-modal {
+    max-width: 95vw;
+    padding: 1.75rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .workflow-table th,
+  .workflow-table td {
+    padding: 0.85rem 0.75rem;
+  }
+
+  .inputs-preview,
+  .error-preview {
+    max-width: 160px;
+  }
+
+  .answer-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .continue-btn,
+  .cancel-btn {
+    width: 100%;
+  }
 }

--- a/apps/frontend/src/App.jsx
+++ b/apps/frontend/src/App.jsx
@@ -1,13 +1,23 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import './App.css'
-import { cancelWorkflow as apiCancel, continueWorkflow as apiContinue, startWorkflow as apiStart, getWorkflow, getWorkflows, getWorkflowTemplates } from './api.js'
+import {
+  cancelWorkflow as apiCancel,
+  continueWorkflow as apiContinue,
+  startWorkflow as apiStart,
+  getWorkflow,
+  getWorkflows,
+  getWorkflowTemplates,
+  retryWorkflow as apiRetry
+} from './api.js'
 import { POLL_INTERVAL_MS } from './constants.js'
 import { startPolling } from './timer.js'
 
 export default function App() {
   const [workflows, setWorkflows] = useState([])
+  const [workflowDetails, setWorkflowDetails] = useState({})
   const [selectedId, setSelectedId] = useState(null)
   const [selected, setSelected] = useState(null)
+  const [showDetailsModal, setShowDetailsModal] = useState(false)
   const [showInterrupt, setShowInterrupt] = useState(false)
   const [expandedSections, setExpandedSections] = useState({
     inputs: true,
@@ -18,24 +28,74 @@ export default function App() {
   const [showStartModal, setShowStartModal] = useState(false)
   const [newTemplate, setNewTemplate] = useState('')
   const [newQuery, setNewQuery] = useState('')
+  const [answer, setAnswer] = useState('')
+
+  const workflowDetailsRef = useRef({})
+  const isMountedRef = useRef(true)
 
   useEffect(() => {
-    const fetchList = () => {
-      getWorkflows().then(data => {
-        setWorkflows(data)
-        setSelectedId(current => {
-          if (current === null && data.length > 0) {
-            return data[0].id
-          }
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  const refreshWorkflows = useCallback(async () => {
+    const list = await getWorkflows()
+    if (!isMountedRef.current) {
+      return []
+    }
+
+    setWorkflows(list)
+
+    const detailEntries = await Promise.all(
+      list.map(async workflow => {
+        try {
+          const detail = await getWorkflow(workflow.id)
+          return [workflow.id, detail]
+        } catch (error) {
+          console.error('Failed to fetch workflow detail', error)
+          return null
+        }
+      })
+    )
+
+    if (!isMountedRef.current) {
+      return list
+    }
+
+    const nextDetails = {}
+    for (const workflow of list) {
+      const detailEntry = detailEntries.find(entry => entry && entry[0] === workflow.id)
+      if (detailEntry) {
+        nextDetails[workflow.id] = detailEntry[1]
+      } else if (workflowDetailsRef.current[workflow.id]) {
+        nextDetails[workflow.id] = workflowDetailsRef.current[workflow.id]
+      }
+    }
+
+    workflowDetailsRef.current = nextDetails
+    setWorkflowDetails(nextDetails)
+    return list
+  }, [])
+
+  useEffect(() => {
+    const load = async () => {
+      const data = await refreshWorkflows()
+      setSelectedId(current => {
+        if (current && data.some(item => item.id === current)) {
           return current
-        })
+        }
+        if (data.length > 0) {
+          return data[0].id
+        }
+        return null
       })
     }
 
-    fetchList()
-    const id = startPolling(fetchList, POLL_INTERVAL_MS)
+    load()
+    const id = startPolling(load, POLL_INTERVAL_MS)
     return () => clearInterval(id)
-  }, [])
+  }, [refreshWorkflows])
 
   useEffect(() => {
     getWorkflowTemplates().then(data => {
@@ -47,16 +107,45 @@ export default function App() {
   }, [])
 
   useEffect(() => {
-    if (!selectedId) return
+    if (!selectedId) {
+      setSelected(null)
+      return
+    }
 
-    getWorkflow(selectedId).then(setSelected)
-  }, [selectedId])
+    const detail = workflowDetails[selectedId]
+    if (detail) {
+      setSelected(detail)
+      return
+    }
+
+    getWorkflow(selectedId).then(data => {
+      workflowDetailsRef.current = {
+        ...workflowDetailsRef.current,
+        [data.id]: data
+      }
+      setWorkflowDetails(current => ({
+        ...current,
+        [data.id]: data
+      }))
+      setSelected(data)
+    })
+  }, [selectedId, workflowDetails])
 
   useEffect(() => {
     if (!selectedId || selected?.status !== 'running') return
 
     const fetchSelected = () => {
-      getWorkflow(selectedId).then(setSelected)
+      getWorkflow(selectedId).then(data => {
+        workflowDetailsRef.current = {
+          ...workflowDetailsRef.current,
+          [data.id]: data
+        }
+        setWorkflowDetails(current => ({
+          ...current,
+          [data.id]: data
+        }))
+        setSelected(data)
+      })
     }
 
     const id = startPolling(fetchSelected, POLL_INTERVAL_MS)
@@ -82,177 +171,213 @@ export default function App() {
   const confirmStartWorkflow = async () => {
     setShowStartModal(false)
     const data = await apiStart(newTemplate, newQuery)
-    setWorkflows([...workflows, { id: data.id, template: newTemplate, status: data.status }])
     setSelectedId(data.id)
-    setSelected(data)
+    setShowDetailsModal(true)
+    await refreshWorkflows()
   }
 
   const cancelStartWorkflow = () => {
     setShowStartModal(false)
   }
 
-  const continueWorkflow = async answer => {
-    const data = await apiContinue(selectedId, answer)
-    setWorkflows(workflows.map(w => (w.id === selectedId ? { ...w, status: data.status } : w)))
-    setSelected(data)
+  const continueWorkflow = async answerValue => {
+    if (!selectedId) return
+
+    const data = await apiContinue(selectedId, answerValue)
+    setWorkflows(prev => prev.map(w => (w.id === selectedId ? { ...w, status: data.status } : w)))
+    setSelected(current => (current ? { ...current, status: data.status, result: data.result ?? current.result } : data))
+    setWorkflowDetails(current => {
+      const next = {
+        ...current,
+        [selectedId]: {
+          ...(current[selectedId] ?? {}),
+          status: data.status,
+          result: data.result ?? current[selectedId]?.result ?? {}
+        }
+      }
+      workflowDetailsRef.current = next
+      return next
+    })
     setShowInterrupt(false)
   }
 
   const cancelRunningWorkflow = async () => {
+    if (!selectedId) return
+
     const data = await apiCancel(selectedId)
-    setWorkflows(workflows.map(w => (w.id === selectedId ? { ...w, status: data.status } : w)))
-    setSelected(data)
+    setWorkflows(prev => prev.map(w => (w.id === selectedId ? { ...w, status: data.status } : w)))
+    setSelected(current => (current ? { ...current, status: data.status, result: data.result ?? current.result } : data))
+    setWorkflowDetails(current => {
+      const next = {
+        ...current,
+        [selectedId]: {
+          ...(current[selectedId] ?? {}),
+          status: data.status,
+          result: data.result ?? current[selectedId]?.result ?? {}
+        }
+      }
+      workflowDetailsRef.current = next
+      return next
+    })
   }
 
-  const toggleSection = (section) => {
+  const toggleSection = section => {
     setExpandedSections(prev => ({
       ...prev,
       [section]: !prev[section]
     }))
   }
 
-  const [answer, setAnswer] = useState('')
+  const formatDateTime = value => {
+    if (!value) return '—'
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) {
+      return value
+    }
+    return date.toLocaleString()
+  }
+
+  const formatErrorPreview = error => {
+    if (!error) return '—'
+    return error.length > 120 ? `${error.slice(0, 117)}…` : error
+  }
+
+  const formatInputsPreview = inputs => {
+    if (!inputs || typeof inputs !== 'object' || Object.keys(inputs).length === 0) {
+      return '—'
+    }
+    try {
+      const text = JSON.stringify(inputs)
+      return text.length > 80 ? `${text.slice(0, 77)}…` : text
+    } catch (error) {
+      return '—'
+    }
+  }
+
+  const openDetailsModal = id => {
+    setExpandedSections({ inputs: true, results: true, error: true })
+    setSelectedId(id)
+    setShowDetailsModal(true)
+    if (!workflowDetails[id]) {
+      getWorkflow(id).then(data => {
+        workflowDetailsRef.current = {
+          ...workflowDetailsRef.current,
+          [data.id]: data
+        }
+        setWorkflowDetails(current => ({
+          ...current,
+          [data.id]: data
+        }))
+        setSelected(data)
+      })
+    }
+  }
+
+  const closeDetailsModal = () => {
+    setShowDetailsModal(false)
+    setShowInterrupt(false)
+    setAnswer('')
+  }
+
+  const handleRetry = async id => {
+    try {
+      await apiRetry(id)
+      await refreshWorkflows()
+      setSelectedId(id)
+      setShowDetailsModal(true)
+    } catch (error) {
+      console.error('Failed to continue workflow', error)
+    }
+  }
+
+  const sortedWorkflows = [...workflows].sort((a, b) => {
+    const aTime = a?.created_at ? new Date(a.created_at).getTime() : 0
+    const bTime = b?.created_at ? new Date(b.created_at).getTime() : 0
+    return bTime - aTime
+  })
+
+  const getDetailForRow = id => workflowDetails[id] ?? null
+
+  const getCreatedAtForSelected = () => {
+    const current = workflows.find(item => item.id === selected?.id)
+    return current?.created_at
+  }
+
   const interrupt = selected?.result?.__interrupt__?.[0]
 
-  // No need to extract specific workflow fields - just show inputs and results as per WorkflowDetail model
-
   return (
-    <div className="container">
-      <aside className="sidebar">
-        <h2>Workflows</h2>
-        <ul className="workflow-list">
-          {workflows.map(w => (
-            <li
-              key={w.id}
-              onClick={() => setSelectedId(w.id)}
-              className={w.id === selectedId ? 'selected' : ''}
-            >
-              <span className="title">{w.template}</span>
-              <span className={`state state-${w.status.replace(/[\s_]+/g, '-').toLowerCase()}`}>{w.status}</span>
-            </li>
-          ))}
-        </ul>
-        <button className="new-workflow" onClick={openStartModal}>Start New Workflow</button>
-      </aside>
-      <main className="content">
-        {selected ? (
-          <>
-            <div className="workflow-header">
-              <h2>{selected.template}</h2>
-              <span className={`status-badge status-${selected.status.replace(/[\s_]+/g, '-').toLowerCase()}`}>
-                {selected.status}
-              </span>
-              {selected.status === 'running' && (
-                <button className="cancel-btn" onClick={cancelRunningWorkflow}>Cancel Workflow</button>
+    <div className="app-shell">
+      <header className="app-header">
+        <div className="header-titles">
+          <h1>Workflow Runs</h1>
+          <p className="subtitle">Track, inspect, and relaunch your workflows from a single view.</p>
+        </div>
+        <button className="primary-btn" onClick={openStartModal}>Start New Workflow</button>
+      </header>
+      <main className="app-main">
+        <div className="table-card">
+          <table className="workflow-table" role="table">
+            <thead>
+              <tr>
+                <th scope="col">Date &amp; Time</th>
+                <th scope="col">Workflow</th>
+                <th scope="col">Status</th>
+                <th scope="col">Error</th>
+                <th scope="col">Inputs</th>
+                <th scope="col" className="actions-header">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedWorkflows.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="empty-state">No workflow runs yet. Start a workflow to see it here.</td>
+                </tr>
+              ) : (
+                sortedWorkflows.map(workflow => {
+                  const detail = getDetailForRow(workflow.id)
+                  return (
+                    <tr
+                      key={workflow.id}
+                      className="workflow-row"
+                      onClick={() => openDetailsModal(workflow.id)}
+                      data-testid={`workflow-row-${workflow.id}`}
+                    >
+                      <td>{formatDateTime(workflow.created_at)}</td>
+                      <td>{detail?.template ?? workflow.template}</td>
+                      <td>
+                        <span className={`status-pill status-${workflow.status.replace(/[\s_]+/g, '-').toLowerCase()}`}>
+                          {workflow.status}
+                        </span>
+                      </td>
+                      <td className="error-preview">{formatErrorPreview(detail?.error)}</td>
+                      <td className="inputs-preview">
+                        <span className="monospace">{formatInputsPreview(detail?.inputs)}</span>
+                      </td>
+                      <td className="actions-cell">
+                        {workflow.status === 'failed' && (
+                          <button
+                            className="table-continue-btn"
+                            onClick={event => {
+                              event.stopPropagation()
+                              handleRetry(workflow.id)
+                            }}
+                          >
+                            Continue
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  )
+                })
               )}
-            </div>
-
-            {showInterrupt && interrupt ? (
-              <div className="interrupt-section">
-                <h3>🤔 Questions</h3>
-                <div className="questions-list">
-                  {interrupt.value.questions.map((question, idx) => (
-                    <p key={idx} className="question">{question}</p>
-                  ))}
-                </div>
-                <div className="answer-input">
-                  <input
-                    value={answer}
-                    onChange={e => setAnswer(e.target.value)}
-                    placeholder="Enter your answer..."
-                    className="answer-field"
-                  />
-                  <button
-                    onClick={() => { continueWorkflow(answer); setAnswer(''); }}
-                    className="continue-btn"
-                  >
-                    Continue
-                  </button>
-                  <button
-                    onClick={() => { setShowInterrupt(false); setAnswer(''); }}
-                    className="cancel-btn"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            ) : selected ? (
-              <div className="workflow-result">
-                {/* Inputs */}
-                {selected.inputs && typeof selected.inputs === 'object' && selected.inputs !== null && Object.keys(selected.inputs).length > 0 && (
-                  <div className="result-section">
-                    <div
-                      className="section-header"
-                      onClick={() => toggleSection('inputs')}
-                    >
-                      <h3>📥 Inputs</h3>
-                      <span className="toggle-icon">
-                        {expandedSections.inputs ? '▼' : '▶'}
-                      </span>
-                    </div>
-                    {expandedSections.inputs && (
-                      <div className="section-content">
-                        <pre className="workflow-data">{JSON.stringify(selected.inputs, null, 2)}</pre>
-                      </div>
-                    )}
-                  </div>
-                )}
-
-                {/* Results */}
-                {selected.result && typeof selected.result === 'object' && selected.result !== null && Object.keys(selected.result).length > 0 && (
-                  <div className="result-section">
-                    <div
-                      className="section-header"
-                      onClick={() => toggleSection('results')}
-                    >
-                      <h3>📤 Results</h3>
-                      <span className="toggle-icon">
-                        {expandedSections.results ? '▼' : '▶'}
-                      </span>
-                    </div>
-                    {expandedSections.results && (
-                      <div className="section-content">
-                        <pre className="workflow-data">{JSON.stringify(selected.result, null, 2)}</pre>
-                      </div>
-                    )}
-                  </div>
-                )}
-
-                {/* Error */}
-                {selected.error && typeof selected.error === 'string' && selected.error.trim() !== '' && (
-                  <div className="result-section">
-                    <div
-                      className="section-header"
-                      onClick={() => toggleSection('error')}
-                    >
-                      <h3>❌ Error</h3>
-                      <span className="toggle-icon">
-                        {expandedSections.error ? '▼' : '▶'}
-                      </span>
-                    </div>
-                    {expandedSections.error && (
-                      <div className="section-content">
-                        <pre className="error-data">{selected.error}</pre>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            ) : (
-              <div className="no-result">
-                <p>No result data available</p>
-              </div>
-            )}
-          </>
-        ) : (
-          <div className="no-selection">
-            <p>Select a workflow to see details</p>
-          </div>
-        )}
+            </tbody>
+          </table>
+        </div>
       </main>
+
       {showStartModal && (
-        <div className="modal-overlay">
-          <div className="modal">
+        <div className="modal-overlay" role="dialog" aria-modal="true">
+          <div className="modal start-modal">
             <h3>Start Workflow</h3>
             <select data-testid="template-select" value={newTemplate} onChange={e => setNewTemplate(e.target.value)}>
               {templates.map(t => (
@@ -268,6 +393,112 @@ export default function App() {
               <button className="cancel-btn" onClick={cancelStartWorkflow}>Cancel</button>
               <button className="start-btn" onClick={confirmStartWorkflow}>Start</button>
             </div>
+          </div>
+        </div>
+      )}
+
+      {showDetailsModal && selected && (
+        <div className="modal-overlay" role="dialog" aria-modal="true" onClick={closeDetailsModal}>
+          <div className="modal detail-modal" onClick={event => event.stopPropagation()}>
+            <div className="modal-header">
+              <div>
+                <h3>{selected.template}</h3>
+                <p className="modal-subtitle">Detailed run information</p>
+              </div>
+              <button className="icon-btn" onClick={closeDetailsModal} aria-label="Close details">×</button>
+            </div>
+
+            <div className="detail-grid">
+              <div className="detail-grid-item">
+                <span className="label">Run ID</span>
+                <span className="value monospace">{selected.id}</span>
+              </div>
+              <div className="detail-grid-item">
+                <span className="label">Status</span>
+                <span className={`status-pill status-${selected.status.replace(/[\s_]+/g, '-').toLowerCase()}`}>
+                  {selected.status}
+                </span>
+              </div>
+              <div className="detail-grid-item">
+                <span className="label">Started</span>
+                <span className="value">{formatDateTime(getCreatedAtForSelected())}</span>
+              </div>
+            </div>
+
+            {selected.inputs && typeof selected.inputs === 'object' && Object.keys(selected.inputs).length > 0 && (
+              <div className="detail-section">
+                <div className="section-header" onClick={() => toggleSection('inputs')}>
+                  <h4>Inputs</h4>
+                  <span className="toggle-icon">{expandedSections.inputs ? '▼' : '▶'}</span>
+                </div>
+                {expandedSections.inputs && (
+                  <pre className="detail-pre">{JSON.stringify(selected.inputs, null, 2)}</pre>
+                )}
+              </div>
+            )}
+
+            {selected.result && typeof selected.result === 'object' && Object.keys(selected.result).length > 0 && (
+              <div className="detail-section">
+                <div className="section-header" onClick={() => toggleSection('results')}>
+                  <h4>Results</h4>
+                  <span className="toggle-icon">{expandedSections.results ? '▼' : '▶'}</span>
+                </div>
+                {expandedSections.results && (
+                  <pre className="detail-pre">{JSON.stringify(selected.result, null, 2)}</pre>
+                )}
+              </div>
+            )}
+
+            {selected.error && (
+              <div className="detail-section">
+                <div className="section-header" onClick={() => toggleSection('error')}>
+                  <h4>Error</h4>
+                  <span className="toggle-icon">{expandedSections.error ? '▼' : '▶'}</span>
+                </div>
+                {expandedSections.error && (
+                  <pre className="detail-pre error-data">{selected.error}</pre>
+                )}
+              </div>
+            )}
+
+            {selected.status === 'running' && (
+              <div className="detail-actions">
+                <button className="cancel-btn" onClick={cancelRunningWorkflow}>Cancel Workflow</button>
+              </div>
+            )}
+
+            {showInterrupt && interrupt && (
+              <div className="interrupt-section">
+                <h3>Questions</h3>
+                <div className="questions-list">
+                  {interrupt.value.questions.map((question, idx) => (
+                    <p key={idx} className="question">{question}</p>
+                  ))}
+                </div>
+                <div className="answer-input">
+                  <input
+                    value={answer}
+                    onChange={e => setAnswer(e.target.value)}
+                    placeholder="Enter your answer..."
+                    className="answer-field"
+                  />
+                  <div className="answer-actions">
+                    <button
+                      onClick={() => { continueWorkflow(answer); setAnswer('') }}
+                      className="continue-btn"
+                    >
+                      Continue
+                    </button>
+                    <button
+                      onClick={() => { setShowInterrupt(false); setAnswer('') }}
+                      className="cancel-btn"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/apps/frontend/src/App.test.jsx
+++ b/apps/frontend/src/App.test.jsx
@@ -1,279 +1,341 @@
-import '@testing-library/jest-dom';
-import { fireEvent, render, screen, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 jest.mock('./constants', () => ({
   API_BASE_URL: '',
-  POLL_INTERVAL_MS: 10000,
-}));
+  POLL_INTERVAL_MS: 10000
+}))
 
 jest.mock('./timer', () => ({
-  startPolling: jest.fn((cb) => {
-    cb();
-    return 1;
-  }),
-}));
+  startPolling: jest.fn(cb => {
+    cb()
+    return 1
+  })
+}))
 
-import App from './App';
+import App from './App'
 
-// Mock react-markdown to avoid ES module issues in tests
 jest.mock('react-markdown', () => {
   return function ReactMarkdown({ children }) {
-    return <div data-testid="markdown-content">{children}</div>;
-  };
-});
+    return <div data-testid="markdown-content">{children}</div>
+  }
+})
 
 beforeEach(() => {
-  global.fetch = jest.fn();
-});
+  global.fetch = jest.fn()
+})
 
 afterEach(() => {
-  jest.resetAllMocks();
-});
+  jest.resetAllMocks()
+})
 
 function mockResponse(data) {
-  return Promise.resolve({ ok: true, json: () => Promise.resolve(data) });
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(data) })
 }
 
 test('workflows display in succeeded, running and waiting states', async () => {
-  fetch.mockImplementation((url) => {
+  const workflows = [
+    { id: '1', template: 'a', status: 'running', created_at: '2024-01-01T00:00:00Z' },
+    { id: '2', template: 'b', status: 'needs_input', created_at: '2024-01-02T00:00:00Z' },
+    { id: '3', template: 'c', status: 'succeeded', created_at: '2024-01-03T00:00:00Z' }
+  ]
+  const details = {
+    1: { id: '1', template: 'a', status: 'running', inputs: {}, result: {} },
+    2: { id: '2', template: 'b', status: 'needs_input', inputs: {}, result: {} },
+    3: { id: '3', template: 'c', status: 'succeeded', inputs: {}, result: {} }
+  }
+
+  fetch.mockImplementation(url => {
     if (url === '/workflows') {
-      return mockResponse([
-        { id: '1', template: 'a', status: 'running' },
-        { id: '2', template: 'b', status: 'needs_input' },
-        { id: '3', template: 'c', status: 'succeeded' }
-      ]);
+      return mockResponse(workflows)
     }
     if (url === '/workflow-templates') {
-      return mockResponse([]);
+      return mockResponse([])
     }
-    return mockResponse({ id: '1', template: 'a', status: 'running', result: {} });
-  });
+    if (url.startsWith('/workflows/')) {
+      const id = url.split('/')[2]
+      return mockResponse(details[id])
+    }
+    return mockResponse({})
+  })
 
-  render(<App />);
+  render(<App />)
 
-  await waitFor(() => expect(fetch).toHaveBeenCalledWith('/workflows'));
-  await screen.findAllByRole('listitem');
+  await screen.findByRole('table')
 
-  expect(document.querySelector('.state-running')).toBeTruthy();
-  expect(document.querySelector('.state-needs-input')).toBeTruthy();
-  expect(document.querySelector('.state-succeeded')).toBeTruthy();
-});
+  await waitFor(() => {
+    expect(document.querySelector('.status-pill.status-running')).toBeTruthy()
+    expect(document.querySelector('.status-pill.status-needs-input')).toBeTruthy()
+    expect(document.querySelector('.status-pill.status-succeeded')).toBeTruthy()
+  })
+})
 
 test('user can start new workflow with selected template', async () => {
+  let workflows = []
+  const details = {}
+
   fetch.mockImplementation((url, options) => {
     if (url === '/workflows' && !options) {
-      return mockResponse([]);
+      return mockResponse(workflows)
     }
     if (url === '/workflow-templates') {
       return mockResponse([
         { id: 'deepresearch', name: 'DeepResearch' },
         { id: 'example', name: 'Example' }
-      ]);
+      ])
     }
     if (url === '/workflows' && options?.method === 'POST') {
-      const body = JSON.parse(options.body);
-      expect(body.template_name).toBe('example');
-      expect(body.query).toBe('my query');
-      return mockResponse({ id: '10', template: 'example', status: 'running', result: {} });
+      const body = JSON.parse(options.body)
+      expect(body.template_name).toBe('example')
+      expect(body.query).toBe('my query')
+      workflows = [
+        { id: '10', template: 'example', status: 'running', created_at: '2024-02-10T10:00:00Z' }
+      ]
+      details['10'] = { id: '10', template: 'example', status: 'running', inputs: {}, result: {} }
+      return mockResponse({ id: '10', template: 'example', status: 'running', result: {} })
     }
-    if (url === '/workflows/10') {
-      return mockResponse({ id: '10', template: 'example', status: 'running', result: {} });
+    if (url.startsWith('/workflows/') && !options) {
+      const id = url.split('/')[2]
+      return mockResponse(details[id] ?? { id, template: 'example', status: 'running', inputs: {}, result: {} })
     }
-    return mockResponse({});
-  });
+    return mockResponse({})
+  })
 
-  render(<App />);
+  render(<App />)
 
-  fireEvent.click(screen.getByText(/Start New Workflow/));
+  fireEvent.click(await screen.findByText(/Start New Workflow/))
 
-  await screen.findByText('Start');
-  fireEvent.change(screen.getByPlaceholderText('Enter query...'), { target: { value: 'my query' } });
-  fireEvent.change(screen.getByTestId('template-select'), { target: { value: 'example' } });
-  fireEvent.click(screen.getByText('Start'));
+  await screen.findByText('Start')
+  fireEvent.change(screen.getByPlaceholderText('Enter query...'), { target: { value: 'my query' } })
+  fireEvent.change(screen.getByTestId('template-select'), { target: { value: 'example' } })
+  fireEvent.click(screen.getByText('Start'))
 
-  await waitFor(() => expect(fetch).toHaveBeenCalledWith('/workflows', expect.objectContaining({ method: 'POST' })));
+  await waitFor(() => expect(fetch).toHaveBeenCalledWith('/workflows', expect.objectContaining({ method: 'POST' })))
 
-  const runningElements = await screen.findAllByText('running');
-  expect(runningElements.length).toBeGreaterThan(0);
-});
+  await screen.findByText('example')
+  const runningBadges = document.querySelectorAll('.status-pill.status-running')
+  expect(runningBadges.length).toBeGreaterThan(0)
+})
 
 test('canceling new workflow does not start it', async () => {
   fetch.mockImplementation((url, options) => {
     if (url === '/workflows' && !options) {
-      return mockResponse([]);
+      return mockResponse([])
     }
     if (url === '/workflow-templates') {
-      return mockResponse([{ id: 'deepresearch', name: 'DeepResearch' }]);
+      return mockResponse([{ id: 'deepresearch', name: 'DeepResearch' }])
     }
     if (url === '/workflows' && options?.method === 'POST') {
-      return mockResponse({});
+      throw new Error('Should not be called')
     }
-    return mockResponse({});
-  });
+    return mockResponse({})
+  })
 
-  render(<App />);
+  render(<App />)
 
-  fireEvent.click(screen.getByText(/Start New Workflow/));
-  await screen.findByText('Start');
-  fireEvent.click(screen.getByText('Cancel'));
+  fireEvent.click(await screen.findByText(/Start New Workflow/))
+  await screen.findByText('Start')
+  fireEvent.click(screen.getByText('Cancel'))
 
-  await waitFor(() => {});
-
-  expect(fetch).not.toHaveBeenCalledWith('/workflows', expect.objectContaining({ method: 'POST' }));
-});
+  await waitFor(() => {})
+  expect(fetch).not.toHaveBeenCalledWith('/workflows', expect.objectContaining({ method: 'POST' }))
+})
 
 test('user can continue waiting workflow', async () => {
+  let workflows = [
+    { id: '5', template: 'deepresearch', status: 'needs_input', created_at: '2024-03-01T10:00:00Z' }
+  ]
+  const details = {
+    5: {
+      id: '5',
+      template: 'deepresearch',
+      status: 'needs_input',
+      inputs: {},
+      result: { __interrupt__: [{ value: { questions: ['clarify?'] } }] }
+    }
+  }
+
   fetch.mockImplementation((url, options) => {
     if (url === '/workflows' && !options) {
-      return mockResponse([{ id: '5', template: 'deepresearch', status: 'needs_input' }]);
+      return mockResponse(workflows)
     }
     if (url === '/workflow-templates') {
-      return mockResponse([]);
+      return mockResponse([])
     }
-    if (url === '/workflows/5') {
-      return mockResponse({
-        id: '5',
-        template: 'deepresearch',
-        status: 'needs_input',
-        result: { __interrupt__: [{ value: { questions: ['clarify?'] } }] }
-      });
+    if (url === '/workflows/5' && !options) {
+      return mockResponse(details[5])
     }
     if (url === '/workflows/5/continue') {
-      return mockResponse({ id: '5', template: 'deepresearch', status: 'succeeded', result: { final_answer: 'done' } });
+      workflows = [
+        { id: '5', template: 'deepresearch', status: 'succeeded', created_at: '2024-03-01T10:00:00Z' }
+      ]
+      details[5] = { id: '5', template: 'deepresearch', status: 'succeeded', inputs: {}, result: { final_answer: 'done' } }
+      return mockResponse({ id: '5', template: 'deepresearch', status: 'succeeded', result: { final_answer: 'done' } })
     }
-    return mockResponse({});
-  });
+    return mockResponse({})
+  })
 
-  render(<App />);
+  render(<App />)
 
-  await screen.findByText('needs_input');
-  await screen.findByPlaceholderText('Enter your answer...');
+  fireEvent.click(await screen.findByTestId('workflow-row-5'))
 
-  fireEvent.change(screen.getByPlaceholderText('Enter your answer...'), { target: { value: 'ok' } });
-  fireEvent.click(screen.getByText('Continue'));
+  await screen.findByPlaceholderText('Enter your answer...')
+  fireEvent.change(screen.getByPlaceholderText('Enter your answer...'), { target: { value: 'ok' } })
+  fireEvent.click(screen.getByText('Continue'))
 
-  await waitFor(() => expect(fetch).toHaveBeenCalledWith('/workflows/5/continue', expect.objectContaining({ method: 'POST' })));
+  await waitFor(() => expect(fetch).toHaveBeenCalledWith('/workflows/5/continue', expect.objectContaining({ method: 'POST' })))
 
-  const elems = await screen.findAllByText('succeeded');
-  expect(elems.length).toBeGreaterThan(0);
-});
+  const succeededBadges = await screen.findAllByText('succeeded')
+  expect(succeededBadges.length).toBeGreaterThan(0)
+})
 
 test('canceling waiting workflow does not send continue request', async () => {
+  const workflows = [
+    { id: '7', template: 'deepresearch', status: 'needs_input', created_at: '2024-03-01T10:00:00Z' }
+  ]
+  const details = {
+    7: {
+      id: '7',
+      template: 'deepresearch',
+      status: 'needs_input',
+      inputs: {},
+      result: { __interrupt__: [{ value: { questions: ['clarify?'] } }] }
+    }
+  }
+
   fetch.mockImplementation((url, options) => {
     if (url === '/workflows' && !options) {
-      return mockResponse([{ id: '7', template: 'deepresearch', status: 'needs_input' }]);
+      return mockResponse(workflows)
     }
     if (url === '/workflow-templates') {
-      return mockResponse([]);
+      return mockResponse([])
     }
-    if (url === '/workflows/7') {
-      return mockResponse({
-        id: '7',
-        template: 'deepresearch',
-        status: 'needs_input',
-        result: { __interrupt__: [{ value: { questions: ['clarify?'] } }] }
-      });
+    if (url === '/workflows/7' && !options) {
+      return mockResponse(details[7])
     }
-    return mockResponse({});
-  });
+    if (url === '/workflows/7/continue') {
+      throw new Error('Should not be called')
+    }
+    return mockResponse({})
+  })
 
-  render(<App />);
+  render(<App />)
 
-  await screen.findByText('needs_input');
-  await screen.findByText('Cancel');
-  fireEvent.click(screen.getByText('Cancel'));
+  fireEvent.click(await screen.findByTestId('workflow-row-7'))
+  await screen.findByPlaceholderText('Enter your answer...')
+  fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
 
-  await waitFor(() => {});
-
-  expect(fetch).not.toHaveBeenCalledWith('/workflows/7/continue', expect.objectContaining({ method: 'POST' }));
-});
+  await waitFor(() => {})
+  expect(fetch).not.toHaveBeenCalledWith('/workflows/7/continue', expect.objectContaining({ method: 'POST' }))
+})
 
 test('user can cancel running workflow', async () => {
+  let workflows = [
+    { id: '9', template: 'deepresearch', status: 'running', created_at: '2024-04-01T09:00:00Z' }
+  ]
+  const details = {
+    9: { id: '9', template: 'deepresearch', status: 'running', inputs: {}, result: {} }
+  }
+
   fetch.mockImplementation((url, options) => {
     if (url === '/workflows' && !options) {
-      return mockResponse([{ id: '9', template: 'deepresearch', status: 'running' }]);
+      return mockResponse(workflows)
     }
     if (url === '/workflow-templates') {
-      return mockResponse([]);
+      return mockResponse([])
     }
-    if (url === '/workflows/9') {
-      return mockResponse({ id: '9', template: 'deepresearch', status: 'running', result: {} });
+    if (url === '/workflows/9' && !options) {
+      return mockResponse(details[9])
     }
     if (url === '/workflows/9/cancel') {
-      return mockResponse({ id: '9', template: 'deepresearch', status: 'canceled', result: {} });
+      workflows = [
+        { id: '9', template: 'deepresearch', status: 'canceled', created_at: '2024-04-01T09:00:00Z' }
+      ]
+      details[9] = { id: '9', template: 'deepresearch', status: 'canceled', inputs: {}, result: {} }
+      return mockResponse({ id: '9', template: 'deepresearch', status: 'canceled', result: {} })
     }
-    return mockResponse({});
-  });
+    return mockResponse({})
+  })
 
-  render(<App />);
+  render(<App />)
 
-  await screen.findByText('running');
-  const btn = await screen.findByText('Cancel Workflow');
-  fireEvent.click(btn);
+  fireEvent.click(await screen.findByTestId('workflow-row-9'))
+  await screen.findByText('Cancel Workflow')
+  fireEvent.click(screen.getByText('Cancel Workflow'))
 
-  await waitFor(() => expect(fetch).toHaveBeenCalledWith('/workflows/9/cancel', expect.objectContaining({ method: 'POST' })));
+  await waitFor(() => expect(fetch).toHaveBeenCalledWith('/workflows/9/cancel', expect.objectContaining({ method: 'POST' })))
 
-  const canceledElems = await screen.findAllByText('canceled');
-  expect(canceledElems.length).toBeGreaterThan(0);
-});
+  const canceledBadges = await screen.findAllByText('canceled')
+  expect(canceledBadges.length).toBeGreaterThan(0)
+})
 
 test('polls workflows periodically', async () => {
-  fetch.mockImplementation((url) => {
+  fetch.mockImplementation(url => {
     if (url === '/workflows') {
-      return mockResponse([]);
+      return mockResponse([])
     }
     if (url === '/workflow-templates') {
-      return mockResponse([]);
+      return mockResponse([])
     }
-    return mockResponse({});
-  });
+    return mockResponse({})
+  })
 
-  render(<App />);
+  render(<App />)
 
-  const timer = require('./timer');
-  await waitFor(() => expect(timer.startPolling).toHaveBeenCalledTimes(1));
-});
+  const timer = require('./timer')
+  await waitFor(() => expect(timer.startPolling).toHaveBeenCalledTimes(1))
+})
 
 test('polls selected workflow only when running', async () => {
-  fetch.mockImplementation((url) => {
+  const workflows = [
+    { id: '1', template: 'a', status: 'running', created_at: '2024-05-01T12:00:00Z' }
+  ]
+  const details = {
+    1: { id: '1', template: 'a', status: 'running', inputs: {}, result: {} }
+  }
+
+  fetch.mockImplementation(url => {
     if (url === '/workflows') {
-      return mockResponse([{ id: '1', template: 'a', status: 'running' }]);
+      return mockResponse(workflows)
     }
     if (url === '/workflow-templates') {
-      return mockResponse([]);
+      return mockResponse([])
     }
     if (url === '/workflows/1') {
-      return mockResponse({ id: '1', template: 'a', status: 'running', result: {} });
+      return mockResponse(details[1])
     }
-    return mockResponse({});
-  });
+    return mockResponse({})
+  })
 
-  render(<App />);
+  render(<App />)
 
-  await waitFor(() => expect(fetch).toHaveBeenCalledWith('/workflows/1'));
-
-  const timer = require('./timer');
-  expect(timer.startPolling).toHaveBeenCalledTimes(2); // list + selected
-});
+  const timer = require('./timer')
+  await waitFor(() => expect(timer.startPolling).toHaveBeenCalledTimes(2))
+})
 
 test('does not poll selected workflow when not running', async () => {
-  fetch.mockImplementation((url) => {
+  const workflows = [
+    { id: '1', template: 'a', status: 'succeeded', created_at: '2024-05-01T12:00:00Z' }
+  ]
+  const details = {
+    1: { id: '1', template: 'a', status: 'succeeded', inputs: {}, result: {} }
+  }
+
+  fetch.mockImplementation(url => {
     if (url === '/workflows') {
-      return mockResponse([{ id: '1', template: 'a', status: 'succeeded' }]);
+      return mockResponse(workflows)
     }
     if (url === '/workflow-templates') {
-      return mockResponse([]);
+      return mockResponse([])
     }
     if (url === '/workflows/1') {
-      return mockResponse({ id: '1', template: 'a', status: 'succeeded', result: {} });
+      return mockResponse(details[1])
     }
-    return mockResponse({});
-  });
+    return mockResponse({})
+  })
 
-  render(<App />);
+  render(<App />)
 
-  await waitFor(() => expect(fetch).toHaveBeenCalledWith('/workflows/1'));
-
-  const timer = require('./timer');
-  expect(timer.startPolling).toHaveBeenCalledTimes(1); // only list
-});
+  const timer = require('./timer')
+  await waitFor(() => expect(timer.startPolling).toHaveBeenCalledTimes(1))
+})

--- a/apps/frontend/src/api.js
+++ b/apps/frontend/src/api.js
@@ -72,3 +72,18 @@ export async function cancelWorkflow(id) {
   })
   return resp.json()
 }
+
+/**
+ * Retry a failed workflow run.
+ * @param {string} id
+ * @returns {Promise<WorkflowResponse>}
+ */
+export async function retryWorkflow(id) {
+  const resp = await fetch(`${BASE_URL}/workflows/${id}/retry`, {
+    method: 'POST'
+  })
+  if (!resp.ok) {
+    throw new Error('Failed to retry workflow')
+  }
+  return resp.json()
+}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -1,70 +1,33 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light;
-  color: #333;
-  background-color: #f0f4f8;
-
+  color: #0f172a;
+  background-color: #f1f5f9;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  min-height: 100vh;
+  background-color: #f1f5f9;
+}
+
+#root {
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+a {
+  color: inherit;
+}
+
+a:hover {
+  color: inherit;
 }
 
 button {
-  border-radius: 8px;
-  border: none;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1976d2;
-  color: #fff;
-  cursor: pointer;
-  transition: opacity 0.25s;
-}
-button:hover {
-  opacity: 0.85;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #1976d2;
-    color: #fff;
-  }
 }


### PR DESCRIPTION
## Summary
- replace the sidebar layout with a centered table view that lists workflow runs with status, error, inputs, and a retry action for failed runs
- add a detail modal that surfaces full run metadata, inputs, results, interrupt handling, and workflow controls alongside a new retry API call
- refresh styling and tests to match the navigation header, table presentation, and modal interactions

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c90ef65d2c8332b3f3c6628b83df0b