### PR TITLE
Add pagination for workflow runs

### DIFF
--- a/apps/backend/backend/models.py
+++ b/apps/backend/backend/models.py
@@ -75,6 +75,13 @@ class WorkflowHistory(BaseModel):
     created_at: str
 
 
+class WorkflowHistoryPage(BaseModel):
+    total: int
+    limit: int
+    offset: int
+    items: list[WorkflowHistory]
+
+
 class WorkflowRunWrite(BaseModel):
     channel: str
     kind: str

--- a/apps/frontend/.gitignore
+++ b/apps/frontend/.gitignore
@@ -1,5 +1,6 @@
 .DS_STORE
 node_modules
+dist/
 scripts/flow/*/.flowconfig
 .flowconfig
 *~

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "prop-types": "^15.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0"
@@ -7203,7 +7204,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -7397,6 +7397,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -8210,6 +8222,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8558,6 +8579,23 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "7.1.0",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "prop-types": "^15.8.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",

--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -223,6 +223,47 @@ body {
   font-size: 1rem;
 }
 
+.table-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  border-top: 1px solid var(--border-color);
+  background-color: var(--card-background);
+}
+
+.pagination-info {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.pagination-controls {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.pagination-btn {
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background-color: #fff;
+  color: var(--text-secondary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.pagination-btn:hover:not(:disabled) {
+  background-color: var(--hover-color);
+  color: var(--text-primary);
+  border-color: var(--primary-color);
+}
+
+.pagination-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 /* Modal Styles */
 .modal-overlay {
   position: fixed;

--- a/apps/frontend/src/api.js
+++ b/apps/frontend/src/api.js
@@ -5,12 +5,17 @@ const BASE_URL = API_BASE_URL
 
 /**
  * Fetch list of workflow runs.
- * @returns {Promise<WorkflowHistory[]>}
+ * @param {Object} [options]
+ * @param {number} [options.limit]
+ * @param {number} [options.offset]
+ * @returns {Promise<WorkflowHistoryPage>}
  */
-export async function getWorkflows() {
+export async function getWorkflows({ limit = 10, offset = 0 } = {}) {
   try {
-    console.log('Fetching workflows from:', `${BASE_URL}/workflows`)
-    const resp = await fetch(`${BASE_URL}/workflows`)
+    const params = new URLSearchParams({ limit: String(limit), offset: String(offset) })
+    const url = `${BASE_URL}/workflows?${params.toString()}`
+    console.log('Fetching workflows from:', url)
+    const resp = await fetch(url)
     console.log('Response status:', resp.status, resp.statusText)
     if (!resp.ok) {
       throw new Error(`HTTP ${resp.status}: ${resp.statusText}`)

--- a/apps/frontend/src/components/WorkflowRunsTable.jsx
+++ b/apps/frontend/src/components/WorkflowRunsTable.jsx
@@ -1,0 +1,142 @@
+import PropTypes from 'prop-types'
+
+export default function WorkflowRunsTable({
+  workflows,
+  workflowDetails,
+  pagination,
+  onSelectRun,
+  onRetry,
+  onContinue,
+  onPageChange,
+  formatDateTime
+}) {
+  const total = pagination?.total ?? workflows.length
+  const limit = pagination?.limit ?? workflows.length
+  const offset = pagination?.offset ?? 0
+  const hasPrevious = offset > 0
+  const hasNext = offset + workflows.length < total
+  const startIndex = total === 0 ? 0 : offset + 1
+  const endIndex = Math.min(offset + workflows.length, total)
+
+  return (
+    <div className="table-card">
+      <table className="workflow-table" role="table">
+        <thead>
+          <tr>
+            <th scope="col">Date &amp; Time</th>
+            <th scope="col">Workflow</th>
+            <th scope="col">Status</th>
+            <th scope="col" className="actions-header">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {workflows.length === 0 ? (
+            <tr>
+              <td colSpan={4} className="empty-state">
+                No workflow runs yet. Start a workflow to see it here.
+              </td>
+            </tr>
+          ) : (
+            workflows.map(workflow => {
+              const detail = workflowDetails?.[workflow.id]
+              return (
+                <tr
+                  key={workflow.id}
+                  className="workflow-row"
+                  onClick={() => onSelectRun(workflow.id)}
+                  data-testid={`workflow-row-${workflow.id}`}
+                >
+                  <td>{formatDateTime(workflow.created_at)}</td>
+                  <td>{detail?.template ?? workflow.template}</td>
+                  <td>
+                    <span className={`status-pill status-${workflow.status.replace(/[\s_]+/g, '-').toLowerCase()}`}>
+                      {workflow.status}
+                    </span>
+                  </td>
+                  <td className="actions-cell">
+                    {workflow.status === 'failed' && (
+                      <button
+                        className="table-continue-btn"
+                        onClick={event => {
+                          event.stopPropagation()
+                          onRetry(workflow.id)
+                        }}
+                      >
+                        Retry
+                      </button>
+                    )}
+                    {workflow.status === 'needs_input' && (
+                      <button
+                        className="table-continue-btn"
+                        onClick={event => {
+                          event.stopPropagation()
+                          onContinue(workflow.id)
+                        }}
+                      >
+                        Continue
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              )
+            })
+          )}
+        </tbody>
+      </table>
+      <div className="table-footer">
+        <div className="pagination-info">
+          {total === 0
+            ? 'No runs available'
+            : `Showing ${startIndex}-${endIndex} of ${total}`}
+        </div>
+        <div className="pagination-controls">
+          <button
+            type="button"
+            className="pagination-btn"
+            onClick={() => hasPrevious && onPageChange(offset - limit)}
+            disabled={!hasPrevious}
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+            className="pagination-btn"
+            onClick={() => hasNext && onPageChange(offset + limit)}
+            disabled={!hasNext}
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+WorkflowRunsTable.propTypes = {
+  workflows: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    created_at: PropTypes.string,
+    template: PropTypes.string,
+    status: PropTypes.string.isRequired
+  })).isRequired,
+  workflowDetails: PropTypes.object,
+  pagination: PropTypes.shape({
+    total: PropTypes.number,
+    limit: PropTypes.number,
+    offset: PropTypes.number
+  }),
+  onSelectRun: PropTypes.func.isRequired,
+  onRetry: PropTypes.func.isRequired,
+  onContinue: PropTypes.func.isRequired,
+  onPageChange: PropTypes.func.isRequired,
+  formatDateTime: PropTypes.func.isRequired
+}
+
+WorkflowRunsTable.defaultProps = {
+  workflowDetails: {},
+  pagination: {
+    total: 0,
+    limit: 0,
+    offset: 0
+  }
+}

--- a/apps/frontend/src/models.js
+++ b/apps/frontend/src/models.js
@@ -11,6 +11,14 @@
  */
 
 /**
+ * @typedef {Object} WorkflowHistoryPage
+ * @property {number} total
+ * @property {number} limit
+ * @property {number} offset
+ * @property {WorkflowHistory[]} items
+ */
+
+/**
  * @typedef {Object} WorkflowDetail
  * @property {string} id
  * @property {string} template

--- a/apps/frontend/src/utils/date.js
+++ b/apps/frontend/src/utils/date.js
@@ -1,0 +1,8 @@
+export function formatDateTime(value) {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+  return date.toLocaleString()
+}


### PR DESCRIPTION
## Summary
- add pagination metadata models and query support to the /workflows API
- refactor the frontend workflow list into a reusable table component with pagination controls
- extract shared date formatting logic and style the new pagination controls; add prop-types dependency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e24f9aada083328acb15ca8ffa9b74